### PR TITLE
Updated shebang for python3 on

### DIFF
--- a/scripts/start_ros_server.py
+++ b/scripts/start_ros_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import rospy
 import moveit_msgs.srv


### PR DESCRIPTION
# Description 
Updated the shebang in start_ros_server.py to use Python 3 since this has to be explicitly stated on Ubuntu 20.04